### PR TITLE
Extend action types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ## 🐷 MES Wizard
 
-**MES Wizard POC** is a simple mock-up app designed to simulate step-by-step actions in a Meat Execution System (MES) environment. It provides a dynamic flow of operations such as confirmations, photo uploads, and label printing, powered by a lightweight Node.js API.
+**MES Wizard POC** is a simple mock-up app designed to simulate step-by-step actions in a Meat Execution System (MES) environment. It provides a dynamic flow of operations such as confirmations, option selections, text entry, photo uploads and label printing, powered by a lightweight Node.js API.
 
 ---
 
 ### 🚀 Features
 
 * Step-by-step action flow (one action at a time)
-* Dynamic action types: confirm, input, photo, label
+* Dynamic action types: confirm, input, select, textarea, photo, label
 * Automatically marks the final step with `finished: true`
 * Fully resettable session via API
 * Simple local image upload and form submission
@@ -82,13 +82,26 @@ Make sure the frontend uses `http://localhost:3001` to communicate with the back
 
 ---
 
+### Default workflow steps
+
+1. **confirm-shoulder** – `confirm`
+2. **remove-injury** – `confirm`
+3. **select-destination** – `select`
+4. **input-weight** – `input`
+5. **note-remarks** – `textarea`
+6. **upload-photo** – `photo`
+7. **print-labels** – `labels`
+
+---
+
 ## 🧪 Example Output
 
 ```json
 [
-  "id": "input-weight",
-  "description": "Enter weight of removed part (kg)",
-  "type": "input",
+  "id": "select-destination",
+  "description": "Where does the removed part go?",
+  "type": "select",
+  "options": ["Processing", "Rendering"],
   "finished": false
 ]
 ```

--- a/mockup-api/server.js
+++ b/mockup-api/server.js
@@ -7,10 +7,20 @@ const upload = multer({ dest: 'uploads/' });
 app.use(cors());
 app.use(express.json());
 
+// List of all possible steps returned one at a time via /next-action
+// Additional action types have been added to better simulate shop floor
+// activities (e.g. selecting a destination or entering remarks).
 let steps = [
   { id: "confirm-shoulder", description: "Is the animal divided?", type: "confirm" },
   { id: "remove-injury", description: "Remove shoulder injury from carcass", type: "confirm" },
+  {
+    id: "select-destination",
+    description: "Where does the removed part go?",
+    type: "select",
+    options: ["Processing", "Rendering"],
+  },
   { id: "input-weight", description: "Enter weight of removed part (kg)", type: "input" },
+  { id: "note-remarks", description: "Add additional remarks", type: "textarea" },
   { id: "upload-photo", description: "Upload picture of removed part", type: "photo" },
   { id: "print-labels", description: "Print new label", type: "labels" },
 ];

--- a/src/App.js
+++ b/src/App.js
@@ -77,6 +77,15 @@ function App() {
     return () => clearTimeout(resetTimer);
   }, [done, countdown, slaughterNumber]);
 
+  // When a new action arrives, prefill values if necessary
+  useEffect(() => {
+    if (currentAction?.type === "select" && Array.isArray(currentAction.options) && currentAction.options.length > 0) {
+      setInputValue(currentAction.options[0]);
+    } else if (currentAction?.type === "textarea") {
+      setInputValue("");
+    }
+  }, [currentAction]);
+
   async function handleSubmit(eventOrValue = null) {
     const value = typeof eventOrValue === 'string' || eventOrValue === null ? (eventOrValue ?? inputValue) : inputValue;
 
@@ -218,6 +227,33 @@ function App() {
                       <input
                         className="border p-2 w-full"
                         type="text"
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                      />
+                      <button className="bg-blue-500 text-white px-4 py-2 mt-2 w-full" onClick={handleSubmit}>Submit</button>
+                    </div>
+                  )}
+
+                  {currentAction.type === "select" && (
+                    <div>
+                      <select
+                        className="border p-2 w-full"
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                      >
+                        {currentAction.options?.map(option => (
+                          <option key={option} value={option}>{option}</option>
+                        ))}
+                      </select>
+                      <button className="bg-blue-500 text-white px-4 py-2 mt-2 w-full" onClick={handleSubmit}>Submit</button>
+                    </div>
+                  )}
+
+                  {currentAction.type === "textarea" && (
+                    <div>
+                      <textarea
+                        className="border p-2 w-full"
+                        rows="4"
                         value={inputValue}
                         onChange={(e) => setInputValue(e.target.value)}
                       />


### PR DESCRIPTION
## Summary
- add select and textarea action types
- update React app to support new actions
- expand mocked API steps
- document workflow and new actions in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c9112f7c08322a490e2efcbe45372